### PR TITLE
Consider QR Links for paper-based presentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -666,8 +666,8 @@ In this flow, the user obtains a physical or virtual *Health Card Link* QR code.
 1. `jwk` value conveying a private key (`"alg": "ECDH-ES", "crv": "P-256"`) capable of decrypting the encrypted Health Card
 
 Consumers can obtain a Health Card Link through two main workflows:
-* For consumers without a smartphone, issuers or other trusted "Health Card Link Creators" can create a Health Card QR Link and print it. In this process, the Health Card Printer generates or obtains a Health Card; generates an encryption key; encrypts the Health Card; and causes the encrypted Health Card to be hosted at some URL. The Health Card Printer then populates a Health Card Link with the three required proeprties, printing the resulting QR code or otherwise sharing it with the consumer.
-* For consumers with a smartphone, their Health Wallet app can play the role of a Health Card Link Creator, following the steps described above.
+* **For consumers *without* a smartphone**, issuers or other trusted "Health Card Link Creators" can create a Health Card QR Link and print it. In this process, the Health Card Printer generates or obtains a Health Card; generates an encryption key; encrypts the Health Card; and causes the encrypted Health Card to be hosted at some URL. The Health Card Printer then populates a Health Card Link with the three required proeprties, printing the resulting QR code or otherwise sharing it with the consumer.
+* **For consumers *with* a smartphone**, their Health Wallet app can play the role of a Health Card Link Creator, following the steps described above.
 
 For an example of a Health Card Link, [see this gist](https://gist.github.com/jmandel/f0f2c846b70f683ec567bfe21497c7e1)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -661,8 +661,8 @@ The process begins with a QR code or `openid://` link. The only differences are:
 
 In this flow, the user obtains a physical or virtual *Health Card Link* QR code. This code can be shared with verifying parties or loaded into a new wallet app by scanning the QR code. The *Health Card Link* is a QR code whose payload consists of a minified JSON payload with three properties:
 
-1. `type` value of `https://smarthealth.cards#health-card`, identifying this QR code as a *Health Card Link*
-1. `url` value that dereferences do an encrypted Health Card (following the same JWE-based encryption scheme described above)
+1. `type` value of `https://smarthealth.cards#1`, identifying this QR code as a *Health Card Link*
+1. `url` value that dereferences to an encrypted Health Card (following the same JWE-based encryption scheme described above)
 1. `jwk` value conveying a private key (`"alg": "ECDH-ES", "crv": "P-256"`) capable of decrypting the encrypted Health Card
 
 Consumers can obtain a Health Card Link through two main workflows:

--- a/docs/index.md
+++ b/docs/index.md
@@ -659,7 +659,7 @@ The process begins with a QR code or `openid://` link. The only differences are:
 * Does not capture a digital record of a signed request (no DID-SIOP Request flow)
 * Does not capture a digital record of the presentation  (no Verifiable Presentation flow)
 
-In this flow, the user obtains a physical or virtual *Health Card Link* QR code. This code can be shared with verifying parties or loaded into a new wallet app by scanning the QR code. The *Health Card Link* is a QR code whose payload consists of a minified JSON payload with three properties:
+In this flow, the user obtains a physical or virtual *Health Card Link* QR code. This code can be shared with verifying parties or loaded into a wallet app by scanning the QR code. The *Health Card Link* is a QR code whose payload consists of a minified JSON payload with three properties:
 
 1. `type` value of `https://smarthealth.cards#1`, identifying this QR code as a *Health Card Link*
 1. `url` value that dereferences to an encrypted Health Card (following the same JWE-based encryption scheme described above)

--- a/docs/index.md
+++ b/docs/index.md
@@ -651,6 +651,26 @@ The process begins with a QR code or `openid://` link. The only differences are:
     ```
 ---
 
+### Paper-based fallback: Health Card Links
+* Allows basic use of health cards for users without a smartphone
+* Allow smartphone-enabled users to print a usable backup
+* Allows full health card contents to be shared with a verifier
+* Requires that the verifier is online
+* Does not capture a digital record of a signed request (no DID-SIOP Request flow)
+* Does not capture a digital record of the presentation  (no Verifiable Presentation flow)
+
+In this flow, the user obtains a physical or virtual *Health Card Link* QR code. This code can be shared with verifying parties or loaded into a new wallet app by scanning the QR code. The *Health Card Link* is a QR code whose payload consists of a minified JSON payload with three properties:
+
+1. `type` value of `https://smarthealth.cards#health-card`, identifying this QR code as a *Health Card Link*
+1. `url` value that dereferences do an encrypted Health Card (following the same JWE-based encryption scheme described above)
+1. `jwk` value conveying a private key (`"alg": "ECDH-ES", "crv": "P-256"`) capable of decrypting the encrypted Health Card
+
+Consumers can obtain a Health Card Link through two main workflows:
+* For consumers without a smartphone, issuers or other trusted "Health Card Link Creators" can create a Health Card QR Link and print it. In this process, the Health Card Printer generates or obtains a Health Card; generates an encryption key; encrypts the Health Card; and causes the encrypted Health Card to be hosted at some URL. The Health Card Printer then populates a Health Card Link with the three required proeprties, printing the resulting QR code or otherwise sharing it with the consumer.
+* For consumers with a smartphone, their Health Wallet app can play the role of a Health Card Link Creator, following the steps described above.
+
+For an example of a Health Card Link, [see this gist](https://gist.github.com/jmandel/f0f2c846b70f683ec567bfe21497c7e1)
+
 ## Potential Extensions
 
 ### Fallback for smartphone-based offline presentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -677,15 +677,5 @@ For an example of a Health Card Link, [see this gist](https://gist.github.com/jm
 
 We should be able to specify additional "return paths" in the DID SIOP workflow that don't depend on an HTTP upload but instead rely on local transfer (e.g., via NFC or bluetooth)
 
-### Fallback for users without a smartphone
-
-While it's hard to provide the same level of functionality and convenience without a mobile phone, there are still steps we can take to allow broader use of these verifiable credentials. Here's one possibleS approach to graceful degradation:
-
-* Lab generates VCs that aren't bound to any specific user DID
-* Lab makes VCs available for download
-* User prints a QR Code conveying the VC, or a link to a hosted copy of the VC (optionally protected by a password or PIN)
-* Verifier scans the barcode, retrieves the VC, and verifies signatures -- then relies on out-of band relationship with the user to match the VC to a real-world identity. For example, the user may be an employee or customer of the verifier, and thus the user's name and phone number may be known by the verifier in advance. The verifier must compare the identity attributes inside the VC with the attributes they have verified out of band.
-
-
 
 [well-known]: https://identity.foundation/.well-known/resources/did-configuration/

--- a/docs/index.md
+++ b/docs/index.md
@@ -666,7 +666,7 @@ In this flow, the user obtains a physical or virtual *Health Card Link* QR code.
 1. `jwk` value conveying a private key (`"alg": "ECDH-ES", "crv": "P-256"`) capable of decrypting the encrypted Health Card
 
 Consumers can obtain a Health Card Link through two main workflows:
-* **For consumers *without* a smartphone**, issuers or other trusted "Health Card Link Creators" can create a QR code and print it. In this process, the Health Card Printer generates or obtains a Health Card; generates an encryption key; encrypts the Health Card; and causes the encrypted Health Card to be hosted at some URL. The Health Card Printer then populates a Health Card Link with the three required proeprties, printing the resulting QR code or otherwise sharing it with the consumer.
+* **For consumers *without* a smartphone**, issuers or other trusted "Health Card Link Creators" can create a QR code and print it. In this process, the Health Card Creator generates or obtains a Health Card; generates an encryption key; encrypts the Health Card; and causes the encrypted Health Card to be hosted at some URL. The Health Card Creator then populates a Health Card Link with the three required proeprties, printing the resulting QR code or otherwise sharing it with the consumer.
 * **For consumers *with* a smartphone**, their Health Wallet app can play the role of a Health Card Link Creator, following the steps described above.
 
 For an example of a Health Card Link, [see this gist](https://gist.github.com/jmandel/f0f2c846b70f683ec567bfe21497c7e1)

--- a/docs/index.md
+++ b/docs/index.md
@@ -666,7 +666,7 @@ In this flow, the user obtains a physical or virtual *Health Card Link* QR code.
 1. `jwk` value conveying a private key (`"alg": "ECDH-ES", "crv": "P-256"`) capable of decrypting the encrypted Health Card
 
 Consumers can obtain a Health Card Link through two main workflows:
-* **For consumers *without* a smartphone**, issuers or other trusted "Health Card Link Creators" can create a QR code and print it. In this process, the Health Card Creator generates or obtains a Health Card; generates an encryption key; encrypts the Health Card; and causes the encrypted Health Card to be hosted at some URL. The Health Card Creator then populates a Health Card Link with the three required proeprties, printing the resulting QR code or otherwise sharing it with the consumer.
+* **For consumers *without* a smartphone**, issuers or other trusted "Health Card Link Creators" can create a QR code and print it. In this process, the Health Card Creator generates or obtains a Health Card; generates an encryption key; encrypts the Health Card; and hosts the encrypted Health Card at some URL. The Health Card Creator then populates a Health Card Link with the three required properties, printing the resulting QR code or otherwise sharing it with the consumer.
 * **For consumers *with* a smartphone**, their Health Wallet app can play the role of a Health Card Link Creator, following the steps described above.
 
 For an example of a Health Card Link, [see this gist](https://gist.github.com/jmandel/f0f2c846b70f683ec567bfe21497c7e1)

--- a/docs/index.md
+++ b/docs/index.md
@@ -666,7 +666,7 @@ In this flow, the user obtains a physical or virtual *Health Card Link* QR code.
 1. `jwk` value conveying a private key (`"alg": "ECDH-ES", "crv": "P-256"`) capable of decrypting the encrypted Health Card
 
 Consumers can obtain a Health Card Link through two main workflows:
-* **For consumers *without* a smartphone**, issuers or other trusted "Health Card Link Creators" can create a Health Card QR Link and print it. In this process, the Health Card Printer generates or obtains a Health Card; generates an encryption key; encrypts the Health Card; and causes the encrypted Health Card to be hosted at some URL. The Health Card Printer then populates a Health Card Link with the three required proeprties, printing the resulting QR code or otherwise sharing it with the consumer.
+* **For consumers *without* a smartphone**, issuers or other trusted "Health Card Link Creators" can create a QR code and print it. In this process, the Health Card Printer generates or obtains a Health Card; generates an encryption key; encrypts the Health Card; and causes the encrypted Health Card to be hosted at some URL. The Health Card Printer then populates a Health Card Link with the three required proeprties, printing the resulting QR code or otherwise sharing it with the consumer.
 * **For consumers *with* a smartphone**, their Health Wallet app can play the role of a Health Card Link Creator, following the steps described above.
 
 For an example of a Health Card Link, [see this gist](https://gist.github.com/jmandel/f0f2c846b70f683ec567bfe21497c7e1)


### PR DESCRIPTION
There are a bunch of trade-offs here that are worth fleshing out. I'd like to get a set of proposals / assessments so we can make a decision.

This link-based approach has clear drawbacks (verifier needs to be online; data are hosted online, even if they can be encrypted and opaque to the hosting provider). The advantage are:

1.  it avoids challenges of unmanageable QR code payload sizes. (Our current data profiles are creeping beyond the boundary of what can fit directly in a QR code, and specific instances can easily be too large, especially if they embed long-form DIDs in addition to signatures.)
2. it avoids the requirement for issuers to create a new/different kind of artifact for the paper-based use case; any already-issued Health Card can be represented with a Health Card Link QR code