### PR TITLE
Consider QR Embedding for paper-based  presentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -664,15 +664,16 @@ In this flow, the user obtains a physical or virtual Health Card QR code. This c
 * `kid` in the JWS header is omitted
 * `sub` in the JWS payload is omitted
 * `iss` in the JWS payload is a short-form ion DID
+* `.vc.issuerDomain` (optional) is populated with the branded domain of the issuer
 * `.vc.credentialSubject.fhirBundle` in the JWS payload is:
   * created without `Resource.meta` elements
   * created without `Resource.text` elements
   * created without `Coding.display` elements
   * minified (i.e., all optional whitespace has been stripped)
  
-The *QR-Ready Health Card* is turned into a QR code by gzipping and then base64 encoding. If the resulting payload is larger than 4296 bytes, the issuer should regenerate the *QR-Ready Health Card* redacting FHIR resources until it is within limits.
+The *QR-Ready Health Card* is turned into a QR code by gzipping and then base64url encoding. If the resulting payload is larger than 4296 bytes, the issuer should refactor the resources into multiple *QR-Ready Health Cards*, populating `.vc.credentialSubject.fhirBundleSplit` with the number of cards in the set, and populating `.vc.credentialSubject.fhirBundleId` with the same UUID for each card in the set.
 
-In order to verify a Health Card QR Code, the verifier must be able to look up the long-form DID value (i.e., the initial state) associated with the issuer's short-form ion DID (e.g., by checking with a registry of known issuer DIDs).
+In order to verify a Health Card QR Code, the verifier must be able to look up the long-form DID value (i.e., the initial state) associated with the issuer's short-form ion DID (e.g., by checking with a registry of known issuer DIDs, or by checking the `.well-known/did-configuration` associated with the `.vc.issuerDomain`).
 
 
 ## Potential Extensions

--- a/docs/index.md
+++ b/docs/index.md
@@ -669,9 +669,10 @@ In this flow, the user obtains a physical or virtual Health Card QR code. This c
   * created without `Resource.meta` elements
   * created without `Resource.text` elements
   * created without `Coding.display` elements
-  * minified (i.e., all optional whitespace has been stripped)
+* entire payload is minified (i.e., all optional whitespace has been stripped)
+* entire payload is gzipped before being signed (i.e., the signed bytes are the minified gzipped JSON payload object)
  
-The *QR-Ready Health Card* is turned into a QR code by gzipping and then base64url encoding. If the resulting payload is larger than 4296 bytes, the issuer should refactor the resources into multiple *QR-Ready Health Cards*, populating `.vc.credentialSubject.fhirBundleSplit` with the number of cards in the set, and populating `.vc.credentialSubject.fhirBundleId` with the same UUID for each card in the set.
+The *QR-Ready Health Card* as a JWT is directly used as the text body of a QR code. If the resulting payload is larger than 4296 bytes, the issuer should refactor the resources into multiple *QR-Ready Health Cards*, populating `.vc.credentialSubject.fhirBundleSplit` with the number of cards in the set, and populating `.vc.credentialSubject.fhirBundleSet` with the same UUID for each card in the set.
 
 In order to verify a Health Card QR Code, the verifier must be able to look up the long-form DID value (i.e., the initial state) associated with the issuer's short-form ion DID (e.g., by checking with a registry of known issuer DIDs, or by checking the `.well-known/did-configuration` associated with the `.vc.issuerDomain`).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -661,6 +661,9 @@ The process begins with a QR code or `openid://` link. The only differences are:
 
 In this flow, the user obtains a physical or virtual Health Card QR code. This code can be shared with verifying parties or loaded into a new wallet app by scanning the QR code. The Health Card QR code is created from a specially-issued *QR-Ready Health Card* with the following constraints applied:
 
+* payload is minified (i.e., all optional whitespace has been stripped)
+* payload is compressed with the DEFLATE (RFC1951) algorithm before being signed
+* `zip: "DEF"` is specified in the JWS header
 * `kid` in the JWS header is omitted
 * `sub` in the JWS payload is omitted
 * `iss` in the JWS payload is a short-form ion DID
@@ -669,8 +672,6 @@ In this flow, the user obtains a physical or virtual Health Card QR code. This c
   * created without `Resource.meta` elements
   * created without `Resource.text` elements
   * created without `Coding.display` elements
-* entire payload is minified (i.e., all optional whitespace has been stripped)
-* entire payload is gzipped before being signed (i.e., the signed bytes are the minified gzipped JSON payload object)
  
 The *QR-Ready Health Card* as a JWT is directly used as the text body of a QR code. If the resulting payload is larger than 4296 bytes, the issuer should refactor the resources into multiple *QR-Ready Health Cards*, populating `.vc.credentialSubject.fhirBundleSplit` with the number of cards in the set, and populating `.vc.credentialSubject.fhirBundleSet` with the same UUID for each card in the set.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -651,20 +651,35 @@ The process begins with a QR code or `openid://` link. The only differences are:
     ```
 ---
 
+### Paper-based fallback: Health Card QR Codes
+* Allows basic use of health cards for users without a smartphone
+* Allow smartphone-enabled users to print a usable backup
+* Allows near-complete health card contents to be shared with a verifier
+* Requires that the verifier has pre-configured a set of known issuers
+* Does not capture a digital record of a signed request (no DID-SIOP Request flow)
+* Does not capture a digital record of the presentation  (no Verifiable Presentation flow)
+
+In this flow, the user obtains a physical or virtual Health Card QR code. This code can be shared with verifying parties or loaded into a new wallet app by scanning the QR code. The Health Card QR code is created from a specially-issued *QR-Ready Health Card* with the following constraints applied:
+
+* `kid` in the JWS header is omitted
+* `sub` in the JWS payload is omitted
+* `iss` in the JWS payload is a short-form ion DID
+* `.vc.credentialSubject.fhirBundle` in the JWS payload is:
+  * created without `Resource.meta` elements
+  * created without `Resource.text` elements
+  * created without `Coding.display` elements
+  * minified (i.e., all optional whitespace has been stripped)
+ 
+The *QR-Ready Health Card* is turned into a QR code by gzipping and then base64 encoding. If the resulting payload is larger than 4296 bytes, the issuer should regenerate the *QR-Ready Health Card* redacting FHIR resources until it is within limits.
+
+In order to verify a Health Card QR Code, the verifier must be able to look up the long-form DID value (i.e., the initial state) associated with the issuer's short-form ion DID (e.g., by checking with a registry of known issuer DIDs).
+
+
 ## Potential Extensions
 
 ### Fallback for smartphone-based offline presentation
 
 We should be able to specify additional "return paths" in the DID SIOP workflow that don't depend on an HTTP upload but instead rely on local transfer (e.g., via NFC or bluetooth)
-
-### Fallback for users without a smartphone
-
-While it's hard to provide the same level of functionality and convenience without a mobile phone, there are still steps we can take to allow broader use of these verifiable credentials. Here's one possibleS approach to graceful degradation:
-
-* Lab generates VCs that aren't bound to any specific user DID
-* Lab makes VCs available for download
-* User prints a QR Code conveying the VC, or a link to a hosted copy of the VC (optionally protected by a password or PIN)
-* Verifier scans the barcode, retrieves the VC, and verifies signatures -- then relies on out-of band relationship with the user to match the VC to a real-world identity. For example, the user may be an employee or customer of the verifier, and thus the user's name and phone number may be known by the verifier in advance. The verifier must compare the identity attributes inside the VC with the attributes they have verified out of band.
 
 
 


### PR DESCRIPTION
This is a different point in the trade-off space from #49. 

Advantages: 

* No need to host (even encrypted) data on the web
* No need for verifier to be online

Disadvantages:
* QR codes are large, making scanning more difficult
* Different processing rules apply to "QR-Ready Health Cards" 
  * Issuers need to understand and support in a specific way
  * Verifiers need to understand and support in a specific way 
* Some content must be stripped from the VC to shrink payload sizes
* Some payloads just might not fit (but for COVID-19 Vaccination Credentials, this should not be a blocking issue)

Discussion questions: If we adopt this model, would we take some of the processing rules here and apply them to normal Health Cards? For example, including only short-form DIDs plus optionally issuer domains, and expecting verifiers to resolve long-form DIDs either from a published trust bundle or from the verifier's `.well-known/did-configuration` endpoint?

 Based on discussion below, next steps are:
- [ ] Draft updates to this PR incorporating the suggestions [here ](https://github.com/smart-on-fhir/health-cards/pull/50#issuecomment-772072678)(@madaster97 would love your help)
- [ ] Provide guidance for keeping `Bundle.entry.fullUrl` values small in size and avoiding references to specific servers -- recommend `resource:1`, `resource:2`, etc as `fullUrl` values to support bundle-local resolution (they are short, internally unique, and avoid external correlation)
- [ ] Get feedback on usability of QR codes vs total size (when printed on paper, and when displayed on phone screens
- [ ] Ensure we're comfortable with the inclusion of a `zip` header in our JWS structures
