### PR TITLE
Simplify API Surface Area for the Health Cards Spec (removing DID, SIOP)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.1.0
+
+Significant API overhaul to reduce scope and simplify dependencies. See [PR#64](https://github.com/smart-on-fhir/health-cards/pull/64) for details.
+
+* Remove user DIDs from the picture. They were already optional, and in some of our most important flows unlikely to be available.
+
+* Remove the need to bind an issuer to a holder ahead of time. SMART on FHIR clients can now call $HealthWallet.issueVc without having to call $HealthWallet.connect first
+
+* Update $HealthWallet.issueVc response to use `valueString` (avoids the need for base64 encoding in the FHIR Parameters resource)
+
+* Replace DID-based key discovery with hosted JSON Web Key. Establish the requirement that Issuers host `.well-known/jwks.json`
+
+* Define requirements for keeping Health Cards' JWS representation small (small enough to fit in a QR code) -- including size limits and a method for splitting a Health Card into a Health Card Set when the size limit cannot be met
+
+* Document process for embedding Health Cards in QR codes
+
+* Update file extension and MIME type for representing Health Cards as downloadable files (`.smart-health-card` and `application/smart-health-card`)
+
+* Remove SIOP flow For Verifier::Holder communications
+
+
 ## 0.0.12
 
 Add optional `resourceLink` response parameter on `$HealthWallet.issueVc`

--- a/docs/index.md
+++ b/docs/index.md
@@ -222,7 +222,7 @@ To facilitate this workflow, the issuer can include a link to help the user down
 
 ### via QR (Print or Scan)
 
-Alternatively, issuers can make the Health Card available **embedded in a QR code** (for instance, printed on a paper-based vaccination record or after-visit summary document). See [Health Cards in QR Codes](#health-cards-in-qr-codes) for details.
+Alternatively, issuers can make the Health Card available **embedded in a QR code** (for instance, printed on a paper-based vaccination record or after-visit summary document). See [details](#every-health-card-can-be-embedded-in-a-qr-code).
 
 Finally, the Health Wallet asks the user if they want to save any/all of the supplied credentials.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -237,7 +237,7 @@ In this step, the user learns that a new Health Card is available (e.g., by rece
 
 ### via File Download
 
-To facilitate this workflow, the issuer can include a link to help the user download the credentials directly, e.g., from at a login-protected page in the Issuer's patient portal. The file should be served with a `.smart-health-card` file extension, so the Health Wallet app can be configured to recognize this extension. Contents should be a JSON object containing an array of Verifiable Credential JWS strings:
+To facilitate this workflow, the issuer can include a link to help the user download the credentials directly, e.g., from at a login-protected page in the Issuer's patient portal. The file SHALL be served with a `.smart-health-card` file extension and SHALL be provided with a MIME type of `application/smart-health-card` (e.g., web servers SHALL include `Content-Type: application/smart-health-card` as an HTTP Response containing a Health Card), so the Health Wallet app can be configured to recognize this extension and/or MIME type. Contents should be a JSON object containing an array of Verifiable Credential JWS strings:
 
 ```json
 {

--- a/docs/index.md
+++ b/docs/index.md
@@ -212,6 +212,9 @@ To ensure that all Health Cards can be represented in QR Codes, the following co
     * without `Resource.text` elements
     * without `CodeableConcept.text` elements
     * without `Coding.display` elements
+    * with `Bundle.entry.fullUrl` populated with short `resource`-scheme URIs (e.g., `{"fullUrl": "resource:0}`)
+    * with `Reference.value` populated with short `resource`-scheme URIs (e.g., `{"patient": {"value": "resource:0"}}`)
+    
 
 When representing a Health Card in a QR code, we aim to ensure that printed (or electronically displayed) codes are usable at physical dimensions of 40mmx40mm. This constraint allows us to use QR codes up to Version 22, at 105x105 modules. Therefore, Issuers SHOULD ensure that the total string length of any Health Card **JWS is <= 1204 characters** (note this is not a typo: 1204 is the limit, not 1024). If it is not possible to include the full `fhirBundle` in a JWS of <1204 characters, Issuers SHOULD use the following techniqe to split a Health Card into a Health Card Set:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -521,7 +521,7 @@ Decision-making often results in a narrowly-scoped "Pass" that embodies conclusi
 
 ## Health Cards in QR Codes
 
-We define a standard way to represent a Health Card in a QR Code. The same strings that appears as `.verifiableCredential[]` entries in a `.smart-health.card` file can be directly represented as QR codes. This approach:
+We define a standard way to represent a Health Card in a QR Code. The JWS strings that appear as `.verifiableCredential[]` entries in a `.smart-health.card` file can be encoded as Numerical Mode QR codes consisting of the digits 0-9 (see ["Numerical Encoding"](#numerical-encoding)). This approach:
 
 * Allows basic storage and sharing of health cards for users without a smartphone
 * Allow smartphone-enabled users to print a usable backup
@@ -546,7 +546,7 @@ To ensure that all Health Cards can be represented in QR Codes, the following co
   * created without `CodeableConcept.text` elements
   * created without `Coding.display` elements
 
-When representing a Health Card in a QR code, we aim to ensure that printed (or electronically displayed) codes are usable at physical dimensions of 35mmx35mm. This constraint allows us to use QR codes up to Version 30, at 137x137 modules. Therefore, Issuers SHOUDL ensure that the total string length of any Health Card **JWS is <= 1732 bytes**. If it is not possible to include the full `fhirBundle` in a JWS of <1732 bytes, Issuers SHOULD use the following techniqe to split a Health Card into a Health Card Set:
+When representing a Health Card in a QR code, we aim to ensure that printed (or electronically displayed) codes are usable at physical dimensions of 35mmx35mm. This constraint allows us to use QR codes up to Version 30, at 137x137 modules. Therefore, Issuers SHOULD ensure that the total string length of any Health Card **JWS is <= 2079 characters**. If it is not possible to include the full `fhirBundle` in a JWS of <2079 characters, Issuers SHOULD use the following techniqe to split a Health Card into a Health Card Set:
 
 * Generate a random "Health Card Set" uuid
 * Partition the `fhirBundle.entry` resources into N groups
@@ -559,8 +559,10 @@ Issuers SHOULD choose "N" as the smallest integer that allows each health card t
 
 At presentation time, a verifier can recognize that a Health Card is part of a Health Card Set by the presence of a `fhirBundleSplit` attribute. When receiving a Health Card with `fhirBundleSplit`, a verifier SHALL ensure that N distinct Health Cards (all with the same issuer and `fhirBundleSet` value) are received, and should create a merged bundle before processing otherwise data integrity cannot be ensured.
 
-When printing or displaying a Health Card as a QR code, the the JWS string value SHALL be represented as text using the default (ISO 8859-1) encoding; the only characters present will be the characters in the base64url encoding character set plus `.` (for a total of 65 distinct characters).
 
+### Numerical Encoding
+
+When printing or displaying a Health Card as a QR code, the the JWS string value SHALL be represented as Numeric Mode value consisting of the characters 0-9. Each character "c" of the JWS is converted into a sequence of two digits as by taking `Ord(c)-45` and treating the result as a two-digit base ten number. For example, `'X'` is encoded as `43`, since `Ord('X')` is `88`, and `88-45` is `43`.
 ## Potential Extensions
 
 ### Fallback for smartphone-based offline presentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -328,16 +328,18 @@ The following limitations apply when presenting Health Card as QR codes, rather 
 
 To ensure that all Health Cards can be represented in QR Codes, the following constraints apply at the time of issuance:
 
-* payload is minified (i.e., all optional whitespace is stripped)
-* payload is compressed with the DEFLATE (see [RFC1951](https://www.ietf.org/rfc/rfc1951.txt)) algorithm before being signed
-* `zip: "DEF"` is specified in the JWS header
-* `kid` in the JWS header is omitted
-* `.vc.credentialSubject.fhirBundle` in the JWS payload is:
-  * created without `Resource.id` elements
-  * created without `Resource.meta` elements
-  * created without `Resource.text` elements
-  * created without `CodeableConcept.text` elements
-  * created without `Coding.display` elements
+* JWS Header
+  * header includes `zip: "DEF"`
+  * header includes `kid` equal to JWK Thumbprint of the key (see [RFC7638](https://tools.ietf.org/html/rfc7638))
+* JWS Payload
+  * payload is minified (i.e., all optional whitespace is stripped)
+  * payload is compressed with the DEFLATE (see [RFC1951](https://www.ietf.org/rfc/rfc1951.txt)) algorithm before being signed
+  * payload `.vc.credentialSubject.fhirBundle` is created:
+    * without `Resource.id` elements
+    * without `Resource.meta` elements
+    * without `Resource.text` elements
+    * without `CodeableConcept.text` elements
+    * without `Coding.display` elements
 
 When representing a Health Card in a QR code, we aim to ensure that printed (or electronically displayed) codes are usable at physical dimensions of 40mmx40mm. This constraint allows us to use QR codes up to Version 22, at 105x105 modules. Therefore, Issuers SHOULD ensure that the total string length of any Health Card **JWS is <= 1204 characters** (note this is not a typo: 1204 is the limit, not 1024). If it is not possible to include the full `fhirBundle` in a JWS of <1204 characters, Issuers SHOULD use the following techniqe to split a Health Card into a Health Card Set:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,15 +60,7 @@ Despite this broad scope, our *short-term definition of success* requires that w
 ## Demo
 Sometimes it's easiest to learn by seeing. For an end-to-end demonstration including Mobile Wallet, Issuer API, and Verifier, see [c19.cards](https://c19.cards/) (source code [on GitHub](https://github.com/microsoft-healthcare-madison/health-wallet-demo) -- and if you want to learn how to test your own components against the demo site, see [README.md](https://github.com/microsoft-healthcare-madison/health-wallet-demo/blob/master/README.md#using-the-hosted-demo-components)).
 
-#### Demo Mobile Wallet: Home Screen
-![](https://i.imgur.com/pMuA3N9.png)
-
-#### Demo Mobile Wallet Approval Screen
-![](https://i.imgur.com/fDdem2h.png)
-
-
 # Design Considerations
-
 This section outlines higher-level design considerations. See ["Protocol Details"](#protocol-details) below for technical details.
 
 ## Data Flow

--- a/docs/index.md
+++ b/docs/index.md
@@ -309,9 +309,7 @@ The **response** is a `Parameters` resource that includes one more more `verifia
   "resourceType": "Parameters",
   "parameter":[{
     "name": "verifiableCredential",
-    "valueAttachment":{
-      "data":"<<base64 encoded VC JWS>>"
-    }
+    "valueString": "<<Health Cards as JWS>>"
   }]
 }
 ```
@@ -325,7 +323,7 @@ In the response, an optional repeating `resourceLink` parameter can capture the 
     "name": "resourceLink",
     "part": [{
         "name": "bundledResource",
-        "valueUri": "urn:uuid:4fe4f8d4-9b6e-4780-8ea5-6b5791230c85"
+        "valueUri": "resource:2"
       }, {
         "name": "hostedResource",
         "valueUri": "https://fhir.example.org/Immunization/123"

--- a/docs/index.md
+++ b/docs/index.md
@@ -369,7 +369,7 @@ The verifier constructs an OIDC request, which is parsed by the Health Wallet an
 ```
 openid://?
   response_type=id_token
-  &scope=did_authn
+  &scope=healthcards_authn
   &request_uri=<<URL where request object can be found>>
   &client_id=<<URL where response object will be posted>>
 ```
@@ -475,7 +475,7 @@ Finally, the Health Wallet submits the  `id_token` and `state` values back to th
 POST <<URL where response object will be posted>>
 Content-type: application/x-www-form-urlencoded
 
-id_token=<<DID SIOP Response Object as JWS or JWE>>
+id_token=<<SIOP Response Object as JWS or JWE>>
 &state=<<state value from SIOP Request Object, if any>>
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 ### Status
 
-Exploratory draft removing DID dependencies. Not tested or reviewed.
+Draft implementation guide authored with input from technology, lab, pharmacy, Electronic Health Record, and Immunization Information System vendors.
 
 ### Contributing
 To propose changes, please use GitHub [Issues](https://github.com/smart-on-fhir/health-cards/issues) or create a [Pull Request](https://github.com/smart-on-fhir/health-cards/pulls).

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,7 +132,7 @@ Each health wallet, issuer, and verifier must be able to generate cryptographic 
  
 ### Determining keys and service endpoints from a JWKS file
 
-Issuers MUST publish keys as JSON Web Key Sets; Verifiers MAY publish keys as JSON Web Key Sets. Given a JWKS URL, any participant can dereference the URL to identify:
+Issuers MUST publish keys as JSON Web Key Sets (see [RFC7517](https://tools.ietf.org/html/rfc7517#section-5)); Verifiers MAY publish keys as JSON Web Key Sets. Given a JWKS URL, any participant can dereference the URL to identify:
 
 * **Encryption keys** used for key agreement when performing `ECDH-ES` encryption. Encryption keys can be identified as entries in the `.keys[]` array whose `.alg` is `"ECDH-ES"` and `use` is `enc`.
 * **Signing keys** used for `ES256` signatures. Signing keys can be identified as entries in the `.keys[]` array whose `.alg` is `"ES256"`  and `use` is `sig

--- a/docs/index.md
+++ b/docs/index.md
@@ -253,13 +253,13 @@ See [Modeling Verifiable Credentials in FHIR](./credential-modeling/) for detail
 
 ## Health Card is ready to save
 
-In this step, the user learns that a new health card is available (e.g., by receiving a text message or email notification). To facilitate this workflow, the issuer can include a link to help the user download the credentials directly, e.g., from at a login-protected page in the Issuer's patient portal. The file should be served with a `.fhir-backed-vc` file extension, so the Health Wallet app can be configured to recognize this extension. Contents should be a JSON object containing an array of Verifiable Credential JWSs:
+In this step, the user learns that a new health card is available (e.g., by receiving a text message or email notification). To facilitate this workflow, the issuer can include a link to help the user download the credentials directly, e.g., from at a login-protected page in the Issuer's patient portal. The file should be served with a `.smart-health-card` file extension, so the Health Wallet app can be configured to recognize this extension. Contents should be a JSON object containing an array of Verifiable Credential JWS strings:
 
 ```json
 {
   "verifiableCredential": [
-    "<<Verifiable Credential as JWE or JWS (see above)>>",
-    "<<Verifiable Credential as JWE or JWS (see above)>>"
+    "<<Verifiable Credential as JWS>>",
+    "<<Verifiable Credential as JWS>>"
   ]
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,7 +113,7 @@ If we identify *optional* data elements for a given use case, we might incorpora
 
 This framework defines a general approach to **representing demographic and clinical data in FHIR**, outlined in [Modeling Verifiable Credentials in FHIR](./credential-modeling/). Specific use cases for Health Cards will define specific data profiles.
 
-  * **COVID-19 Vaccination Credentials**: See [SMART Health Cards: Vaccination IG"](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main)
+  * **COVID-19 Vaccination Credentials**: See [SMART Health Cards: Vaccination IG](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main)
 
 # Protocol Details
 
@@ -125,15 +125,15 @@ The following key types are used in the Health Cards Framework, represented as J
 * **Signing Keys**
   * MUST have `"kty": "EC"`, `"use": "sig"`, and `"alg": "ES256"`
   * MUST have `"kid"` equal to JWK Thumbprint of the key (see [RFC7638](https://tools.ietf.org/html/rfc7638))
-  * Signing Health Cards (a.k.a. Verifiable Credentials)
+  * Signing *Health Cards* (a.k.a. Verifiable Credentials)
     * Issuers sign Health Card VCs with a signing key (private key)
     * Issuer publish their signing keys (public key) at `.well-known/jwks.json`
     * Wallets and Verifers validate Issuer signatures on Health Cards
-  * Signing [SIOP Requests](#siop-request) (requests for presentation of Health Cards)
+  * Signing *[SIOP Requests](#siop-request)* (requests for presentation of Health Cards)
     * Verifiers sign SIOP request objects with a signing key
     * Verifiers publish their signing keys  (public key) at `.well-known/jwks.json`
     * Wallets validate Verifier signatures on SIOP requests
-  * Signing SIOP Responses(#siop-response) (a.k.a Verifiable Presentations, a.k.a. `id_token`s)
+  * Signing *[SIOP Responses](#siop-response)* (a.k.a Verifiable Presentations, a.k.a. `id_token`s)
     * Wallets sign SIOP Responses a signing key (private key)
     * Wallets include their signing keys in the body of the `id_token` using the `sub_jwk` parameter
     * Verifiers validate signatures on SIOP Responses
@@ -142,7 +142,7 @@ The following key types are used in the Health Cards Framework, represented as J
   * MUST have `"kty": "EC"`, `"use": "enc"`, `"alg": "ECDH-ES"` and `"enc": "A256GCM"` 
   * MUST have `"kid"` equal to JWK Thumbprint of the key (see [RFC7638](https://tools.ietf.org/html/rfc7638))
   * Verifiers publish their encryption keys (public key) at `.well-known/jwks.json`
-  * Encrypting SIOP Responses(#siop-response) (a.k.a Verifiable Presentations, a.k.a. `id_token`s)
+  * Encrypting *[SIOP Responses](#siop-response)* (a.k.a Verifiable Presentations, a.k.a. `id_token`s)
     * Verifiers can request encrypted SIOP response with `id_token_encrypted_response_*` request parameters
     * Wallets encrypt Verifiable Presentations (`id_token`s) to a verifier's encryption key upon request
     * Verifiers decrypt SIOP Responses when they are encrypted
@@ -507,7 +507,7 @@ id_token=<<SIOP Response Object as JWS or JWE>>
 ## Which clinical data should be considered in decision-making?
 * The data in Health Cards should focus on communicating "immutable clinical facts".
 * Each use case will define specific data profiles.
-  * For COVID-19 Vaccination Credentials, the [SMART Health Cards: Vaccination IG"](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main) defines requirements
+  * For COVID-19 Vaccination Credentials, the [SMART Health Cards: Vaccination IG](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main) defines requirements
 * When Health Cards are used in decision-making, the verifier is responsible for deciding what rules to apply
   * decision-making rules may change over time as our understanding of the clinical science improves
   * decision-making rules may be determined or influenced by international, national and local health authorities
@@ -527,4 +527,7 @@ We should be able to specify additional "return paths" in the SIOP workflow that
 
 # References
 
-[SIOP]: https://openid.net/specs/openid-connect-core-1_0.html#SelfIssued
+* JSON Web Key (JWK): https://tools.ietf.org/html/rfc7517
+* JSON Web Key (JWK) Thumbprint: https://tools.ietf.org/html/rfc7638
+* Self-Issued OpenID Provider (SIOP): https://openid.net/specs/openid-connect-core-1_0.html#SelfIssued
+* SMART Health Cards Vaccination IG: http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main

--- a/docs/index.md
+++ b/docs/index.md
@@ -175,10 +175,11 @@ note over Issuer, Holder: Later...
 Issuer ->> Holder: Holder receives Health Card
 ```
 
-See [Modeling Verifiable Credentials in FHIR](./credential-modeling/) for details. The overall VC structure looks like the following:
+### Health Cards are encoded as Compact Serialization JSON Web Signatures (JWS)
 
-!!! info "VCs look different when represented as JWTs"
-    The example below shows a VC using the "vanilla" JSON representation. When packaging a VC into a JSON Web Token payload, there are a few differences, to retain compatibility with standard JWT claims. For example, compare [this "vanilla" JSON representation](https://github.com/microsoft-healthcare-madison/health-wallet-demo/blob/master/src/fixtures/vc.json) with its [corresponding JWT payload](https://github.com/microsoft-healthcare-madison/health-wallet-demo/blob/master/src/fixtures/vc-jwt-payload.json). Note that in the JWT payload, most properties have been pushed into a `.vc` claim; there is no top-level `issuer`, `issuanceDate`, `@context` or `@type` property, because these are all ahcnored inside the `.vc` claim. The overall structure is:
+The VC structure (scaffold) is shown in the following example.  The Health Cards framework serializes VCs using the compact JWS serialization, i.e. each Health Card is a signed JSON Web Token. Specific encoding choices ensure compatibility with standard JWT claims, as described at https://www.w3.org/TR/vc-data-model/#jwt-encoding. Specifically: in the JWT payload, most properties have been "pushed down" into a `.vc` claim; there is no top-level `issuer`, `issuanceDate`, `@context`, `@type`, or `credentialSubject` property, because these fields are either mapped into standard JWT claims (for `iss`, `iat`) or included within the `.vc` claim (for `@context`, `@type`, `@credentialSubject`).
+
+Hence, the overall JWS payload matches the following structure (before it is [minified and compressed](#every-health-card-can-be-embedded-in-a-qr-code)):
 
 ```json
 {
@@ -202,6 +203,7 @@ See [Modeling Verifiable Credentials in FHIR](./credential-modeling/) for detail
   }
 }
 ```
+
 
 ## User Retrieves Health Cards
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -546,7 +546,7 @@ To ensure that all Health Cards can be represented in QR Codes, the following co
   * created without `CodeableConcept.text` elements
   * created without `Coding.display` elements
 
-When representing a Health Card in a QR code, we aim to ensure that printed (or electronically displayed) codes are usable at physical dimensions of 35mmx35mm. This constraint allows us to use QR codes up to Version 30, at 137x137 modules. Therefore, Issuers SHOULD ensure that the total string length of any Health Card **JWS is <= 2079 characters**. If it is not possible to include the full `fhirBundle` in a JWS of <2079 characters, Issuers SHOULD use the following techniqe to split a Health Card into a Health Card Set:
+When representing a Health Card in a QR code, we aim to ensure that printed (or electronically displayed) codes are usable at physical dimensions of 40mmx40mm. This constraint allows us to use QR codes up to Version 22, at 105x105 modules. Therefore, Issuers SHOULD ensure that the total string length of any Health Card **JWS is <= 1204 characters** (note this is not a typo: 1204 is the limit, not 1024). If it is not possible to include the full `fhirBundle` in a JWS of <1204 characters, Issuers SHOULD use the following techniqe to split a Health Card into a Health Card Set:
 
 * Generate a random "Health Card Set" uuid
 * Partition the `fhirBundle.entry` resources into N groups

--- a/docs/index.md
+++ b/docs/index.md
@@ -562,7 +562,8 @@ At presentation time, a verifier can recognize that a Health Card is part of a H
 
 ### Numerical Encoding
 
-When printing or displaying a Health Card as a QR code, the the JWS string value SHALL be represented as Numeric Mode value consisting of the characters 0-9. Each character "c" of the JWS is converted into a sequence of two digits as by taking `Ord(c)-45` and treating the result as a two-digit base ten number. For example, `'X'` is encoded as `43`, since `Ord('X')` is `88`, and `88-45` is `43`.
+When printing or displaying a Health Card as a QR code, the the JWS string value SHALL be represented as a Numeric Mode value consisting of the characters `0`-`9`. Each character "c" of the JWS is converted into a sequence of two digits as by taking `Ord(c)-45` and treating the result as a two-digit base ten number. For example, `'X'` is encoded as `43`, since `Ord('X')` is `88`, and `88-45` is `43`. (The constant "45" appears here because it is the ordinal value of `-`, the lowest-valued character that can appear in a compact JWS. Subtracting 45 from the ordinal values of valid JWS characters produces a range between 00 and 99, ensuring that each character of the JWS can be represented in exactly two base-10 numeric digits.)
+
 ## Potential Extensions
 
 ### Fallback for smartphone-based offline presentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -564,6 +564,8 @@ At presentation time, a verifier can recognize that a Health Card is part of a H
 
 When printing or displaying a Health Card as a QR code, the the JWS string value SHALL be represented as a Numeric Mode value consisting of the characters `0`-`9`. Each character "c" of the JWS is converted into a sequence of two digits as by taking `Ord(c)-45` and treating the result as a two-digit base ten number. For example, `'X'` is encoded as `43`, since `Ord('X')` is `88`, and `88-45` is `43`. (The constant "45" appears here because it is the ordinal value of `-`, the lowest-valued character that can appear in a compact JWS. Subtracting 45 from the ordinal values of valid JWS characters produces a range between 00 and 99, ensuring that each character of the JWS can be represented in exactly two base-10 numeric digits.)
 
+(The reason for representing Health Cards using Numeric Mode QRs instead of Binary Mode (Latin-1) QRs is information density: with Numeric Mode, 20% more data can fit in a given QR, vs Binary Mode. This is because the JWS character set conveys only log_2(65) bits per character (~6 bits); binary encoding requires log_2(256) bits per character (8 bits), which means ~2 wasted bits per character.)
+
 ## Potential Extensions
 
 ### Fallback for smartphone-based offline presentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ This section outlines higher-level design considerations. See ["Protocol Details
 Each step in the flow must have well-defined inputs and outputs. For each step we define at least one required data transfer method to establish a basis for interoperability.
 
 ### Connecting Health Wallet to Issuer (optional)
-* Establish a SMART on FHIR authorization with an Issuer including the `__HealthWallet.*` scope
+* Establish a SMART on FHIR authorization with an Issuer including read access to any resources that will be present in Health Cards (e.g., Patient, Immunization, Observation, DiagnosticReport).
 
 ### Getting credentials into Health Wallet
 * Required method: File download
@@ -162,16 +162,16 @@ Issuers MUST publish keys as JSON Web Key Sets; Verifiers MAY publish keys as JS
 
 ## Connect Health Wallet to Issuer Account
 
-For issuers that support SMART on FHIR access, the Health Wallet MAY request authorization for the `__HealthWallet.*` scope. This allows the Health Wallet to automatically request issuance of VCs, including requests for periodic updates.
+For issuers that support SMART on FHIR access, the Health Wallet MAY request authorization with SMART on FHIR scopes (e.g., `launch/patient patient/Immunization.read` for an Immunization use case). This allows the Health Wallet to automatically request issuance of VCs, including requests for periodic updates.
 
-A SMART on FHIR Server advertises support for issuing VCs according to this specification by adding the `health-cards` capability and the `__HealthWallet.*` scope to its `.well-known/smart-configuration` JSON file. For example:
+A SMART on FHIR Server advertises support for issuing VCs according to this specification by adding the `health-cards` capability to its `.well-known/smart-configuration` JSON file. For example:
 
 ```
 {
 "authorization_endpoint": "https://ehr.example.com/auth/authorize",
 "token_endpoint": "https://ehr.example.com/auth/token",
 "token_endpoint_auth_methods_supported": ["client_secret_basic"],
-"scopes_supported": ["__HealthWallet.*", "launch", "launch/patient", "patient/*.*", "offline_access"],
+"scopes_supported": ["launch", "launch/patient", "patient/*.*", "offline_access"],
 "response_types_supported": ["code", "code id_token", "id_token", "refresh_token"],
 "capabilities": ["health-cards", "launch-standalone", "context-standalone-patient", "client-confidential-symmetric"]
 }


### PR DESCRIPTION
Looking at the number of in-flight efforts focused on sharing immunization records with consumers, it's more important than ever that we focus the specification with an eye to implementability and equal access for users without smartphones.

Over the weekend I tried the experiment of: "given what we know now about how Health Card VCs are going to be used, how could we simplify the SMART Health Cards spec?" Here's what came to mind:

* We could **eliminate user DIDs** from the picture. They're already optional, and in some of our most important flows they're unlikely to be available. They provide _some_ additional information to a verifier (basically: the device making this presentation was also able to access a patient portal account at some point), but this information isn't really actionable.

* Without user DIDs, we could **eliminate the need to bind an issuer to a holder** ahead of time. This means we could allow OAuth-authorized SMART on FHIR clients to call `$HealthWallet.issueVc` without having to call `$HealthWallet.connect` first.

* We could **replace issuer DIDs with hosted JSON Web Key Sets**. Basically, if we assume that issuers can be identified by URL, then we can establish the convention that `.well-known/jwks.json` should be available. This allows verifiers (or trust frameworks) to easily find and cache results. While it doesn't offer all the benefits of a decentralized system, it solves the problem at hand in a reasonably decentralized way (i.e., issuers can act independently and can be trusted independently, with an overlay-based trust framework); and it gives us a place to tie in things like certificate chains for hierarchical trust if we want that down the line.

* For Verifier::Holder conversations, we could replace the "DID SIOP" flow with a combination of QR-based presentations (for paper users, or smartphone users who don't want a "full wallet" app experience) and on-device inter-app communications (where a 3rd party app can request specific health cards from a wallet on-device)

####  What do we gain:

* Simpler, smaller surface area for implementation
* Focus on capabilities that have strong cross-platform library support
* Cut dependencies on specs that are still work-in-progress

#### What are the downsides:

* (Maybe) Less interop with the ecosystem of DID-based self-sovreign identity protocols (though our focus on VCs rather than presentation protocols may actually make integration with such wallets *easier*)
* Issuers need to maintain a stable web presence, or else trust frameworks need to maintain a list of historical JWKS values
* While verifiers can be sure the VC came from a specific issuer based on the JWS, they won't know if the VC was initially issued for a specific holder app directly from a patient portal vs (say) by taking a photo of a QR code over someone's shoulder. This is mitigated by the fact that the contents speak for themselves (i.e., act as a bearer credential with a tamper-proof signature), which has always been the core basis for trust.
