### PR TITLE
clarify Meta is allowed in one special case

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+##0.4.4
+
+Resource.meta is allowed in one special case
+
 ## 0.4.3
 
 Document CORS expectation for `.well-known/jwks.json`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-##0.4.4
+## 0.4.4
 
 Resource.meta is allowed in one special case
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -253,7 +253,7 @@ To ensure that all Health Cards can be represented in QR Codes, issuers SHALL en
     * payload is compressed with the DEFLATE (see [RFC1951](https://www.ietf.org/rfc/rfc1951.txt)) algorithm before being signed (note, this should be "raw" DEFLATE compression, omitting any zlib or gz headers)
     * payload `.vc.credentialSubject.fhirBundle` is created:
         * without `Resource.id` elements
-        * without `Resource.meta` elements
+        * without `Resource.meta` elements (or if present, `.meta.security` is included and no other fields are included)
         * without `Resource.text` elements
         * without `CodeableConcept.text` elements
         * without `Coding.display` elements


### PR DESCRIPTION
http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/#identity-assurance wound up using Meta for one purpose.