### PR TITLE
Adds clarification for nbf encoding

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -486,7 +486,7 @@ The spec is currently focused on representing Health Cards in a standardized dat
 
 # References
 
-* DEFLATE Compression: https://www.ietf.org/rfc/rfc1951.txt
+* DEFLATE Compression: https://tools.ietf.org/html/rfc1951
 * JSON Web Token (JWT): https://tools.ietf.org/html/rfc7519
 * JSON Web Key (JWK): https://tools.ietf.org/html/rfc7517
 * JSON Web Key (JWK) Thumbprint: https://tools.ietf.org/html/rfc7638

--- a/docs/index.md
+++ b/docs/index.md
@@ -216,7 +216,7 @@ Issuer ->> Holder: Holder receives Health Card
 
 The VC structure (scaffold) is shown in the following example.  The Health Cards framework serializes VCs using the compact JWS serialization, where the payload is a compressed set of JWT claims (see [Appendix 3 of RFC7515](https://tools.ietf.org/html/rfc7515#appendix-A.3) for an example using ECDSA P-256 SHA-256, as required by this specification). Specific encoding choices ensure compatibility with standard JWT claims, as described at [https://www.w3.org/TR/vc-data-model/#jwt-encoding](https://www.w3.org/TR/vc-data-model/#jwt-encoding).
 
-The `@context`, `type`, and `credentialSubject` properties are added to the `vc` claim of the JWT. The `issuer` property is represented by the registered JWT `iss` claim and the `issuanceDate` property is represented by the registered JWT `nbf` claim.  Hence, the overall JWS payload matches the following structure (before it is [minified and compressed](#health-cards-are-small)):
+The `@context`, `type`, and `credentialSubject` properties are added to the `vc` claim of the JWT. The `issuer` property is represented by the registered JWT `iss` claim and the `issuanceDate` property is represented by the registered JWT `nbf` (not before) claim (encoded as the number of seconds from 1970-01-01T00:00:00Z UTC, as specified by [RFC 7519](https://tools.ietf.org/html/rfc7519)).  Hence, the overall JWS payload matches the following structure (before it is [minified and compressed](#health-cards-are-small)):
 
 ```json
 {

--- a/docs/index.md
+++ b/docs/index.md
@@ -487,5 +487,6 @@ The spec is currently focused on representing Health Cards in a standardized dat
 # References
 
 * DEFLATE Compression: https://www.ietf.org/rfc/rfc1951.txt
+* JSON Web Token (JWT): https://tools.ietf.org/html/rfc7519
 * JSON Web Key (JWK): https://tools.ietf.org/html/rfc7517
 * JSON Web Key (JWK) Thumbprint: https://tools.ietf.org/html/rfc7638

--- a/docs/index.md
+++ b/docs/index.md
@@ -216,7 +216,7 @@ Issuer ->> Holder: Holder receives Health Card
 
 The VC structure (scaffold) is shown in the following example.  The Health Cards framework serializes VCs using the compact JWS serialization, where the payload is a compressed set of JWT claims (see [Appendix 3 of RFC7515](https://tools.ietf.org/html/rfc7515#appendix-A.3) for an example using ECDSA P-256 SHA-256, as required by this specification). Specific encoding choices ensure compatibility with standard JWT claims, as described at [https://www.w3.org/TR/vc-data-model/#jwt-encoding](https://www.w3.org/TR/vc-data-model/#jwt-encoding).
 
-The `@context`, `type`, and `credentialSubject` properties are added to the `vc` claim of the JWT. The `issuer` property is represented by the registered JWT `iss` claim and the `issuanceDate` property is represented by the registered JWT `nbf` (not before) claim (encoded as the number of seconds from 1970-01-01T00:00:00Z UTC, as specified by [RFC 7519](https://tools.ietf.org/html/rfc7519)).  Hence, the overall JWS payload matches the following structure (before it is [minified and compressed](#health-cards-are-small)):
+The `@context`, `type`, and `credentialSubject` properties are added to the `vc` claim of the JWT. The `issuer` property is represented by the registered JWT `iss` claim and the `issuanceDate` property is represented by the registered JWT `nbf` ("not before") claim (encoded as the number of seconds from 1970-01-01T00:00:00Z UTC, as specified by [RFC 7519](https://tools.ietf.org/html/rfc7519)).  Hence, the overall JWS payload matches the following structure (before it is [minified and compressed](#health-cards-are-small)):
 
 ```json
 {


### PR DESCRIPTION
Provide clarity on how to properly encode the `nbf` value (c.f., [issue 46](https://github.com/microsoft/health-cards-validation-SDK/issues/46) on the validation SDK) 