### PR TITLE
Clarify requirements for numeric encoding

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -417,7 +417,7 @@ The following limitations apply when presenting Health Card as QR codes, rather 
 
 ### Chunking
 
-Commonly, Health Cards will fit in a single V22 QR code.  Any JWS longer than 1195 characters SHALL be split into "chunks" of length 1191 or smaller; each chunk SHALL be encoded as a separate QR code to ensure ease of scanning. Each chunk SHALL be numerically encoded and prefixed with an ordinal as well as the total number of chunks required to re-assemble the JWS, as described below.
+Commonly, Health Cards will fit in a single V22 QR code.  Any JWS longer than 1195 characters SHALL be split into "chunks" of length 1191 or smaller; each chunk SHALL be encoded as a separate QR code of V22 or lower, to ensure ease of scanning. Each chunk SHALL be numerically encoded and prefixed with an ordinal as well as the total number of chunks required to re-assemble the JWS, as described below.
 
 To ensure the best user experience when producing and consuming multiple QR Codes:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -417,7 +417,7 @@ The following limitations apply when presenting Health Card as QR codes, rather 
 
 ### Chunking
 
-Commonly, Health Cards will fit in a single V22 QR code.  Any JWS longer than 1195 characters is split into "chunks" of length 1191 or smaller; each chunk is then encoded as a separate QR code to ensure ease of scanning. Each chunk is numerically encoded and prefixed with an ordinal as well as the total number of chunks required to re-assemble the JWS, as described below.
+Commonly, Health Cards will fit in a single V22 QR code.  Any JWS longer than 1195 characters SHALL be split into "chunks" of length 1191 or smaller; each chunk SHALL be encoded as a separate QR code to ensure ease of scanning. Each chunk SHALL be numerically encoded and prefixed with an ordinal as well as the total number of chunks required to re-assemble the JWS, as described below.
 
 To ensure the best user experience when producing and consuming multiple QR Codes:
 
@@ -426,7 +426,7 @@ To ensure the best user experience when producing and consuming multiple QR Code
 
 ### Encoding Chunks as QR Codes
 
-When printing or displaying a Health Card using QR codes, let "N" be the total number of chunks required, and let "C" be a variable indicating the index of the current chunk. Each chunk of the JWS string value is represented as a QR with two data segments:
+When printing or displaying a Health Card using QR codes, let "N" be the total number of chunks required, and let "C" be a variable indicating the index of the current chunk. Each chunk of the JWS string value SHALL be represented as a QR with two data segments:
 
 1. A segment encoded with `bytes` mode consisting of 
     * the fixed string `shc:/` 


### PR DESCRIPTION
This results from issues like https://github.com/microsoft/health-cards-validation-SDK/issues/73 where implementers may have missed the expectation to use *numeric* encoding in QRs. We want to make sure the validator raises an error in this case, and the spec should be clear.

From my comments on that issue:

> The entire rationale or our numeric encoding scheme is to enable higher-density QRs. If an implementation is allowed to translate a JWS to digits but then to use byte encoding instead of numeric encoding for those digits, we'd be blowing up payload sizes by >200% (i.e., we'd be packing only 5 JWS characters per 10 QR bytes, instead of 12 JWS characters per 10 QR bytes). If this was going to be OK, we'd do better to use some other encoding scheme.