### PR TITLE
`text` is an element on DomainResource

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -222,7 +222,7 @@ To ensure that all Health Cards can be represented in QR codes, issuers SHALL en
     * payload `.vc.credentialSubject.fhirBundle` is created:
         * without `Resource.id` elements
         * without `Resource.meta` elements (or if present, `.meta.security` is included and no other fields are included)
-        * without `Resource.text` elements
+        * without `DomainResource.text` elements
         * without `CodeableConcept.text` elements
         * without `Coding.display` elements
         * with `Bundle.entry.fullUrl` populated with short `resource`-scheme URIs (e.g., `{"fullUrl": "resource:0}`)


### PR DESCRIPTION
`text` is an element on `DomainResource`, not `Resource`

[FHIR R4 DomainResource.text](https://www.hl7.org/fhir/domainresource-definitions.html#DomainResource.text)
[FHIR R4 Resource](https://www.hl7.org/fhir/resource.html)