### PR TITLE
Specify FHIR API response when there are no $health-cards-issue operation results

### DIFF
--- a/docs/artifacts/operation-patient-i-health-cards-issue.json
+++ b/docs/artifacts/operation-patient-i-health-cards-issue.json
@@ -40,7 +40,7 @@
   }, {
     "name": "verifiableCredential",
     "use": "out",
-    "min": 1,
+    "min": 0,
     "max": "*",
     "type": "string"
   }, {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+Clarify FHIR API behavior when `$health-cards-issue` doesn't return results
+
 ## 1.0.0
 
 No functional change from 1.0.0-rc; added documentation links and re-worked introduction.

--- a/docs/index.md
+++ b/docs/index.md
@@ -287,8 +287,8 @@ A Health Wallet can `POST /Patient/:id/$health-cards-issue` to a FHIR-enabled is
 }
 ```
 
-The `credentialType` parameter is required. Multiple `credentialType` values in one request SHALL be intepreted as a request for the intersection of the requested types (logical AND).
-For example, a request containing `credentialType` values `https://smarthealth.cards#covid19` and `https://smarthealth.cards#immunization` is a request for only those cards that are both Covid-19 cards and immunization cards (i.e., only those Covid-19 cards that are about immunizations).
+The `credentialType` parameter is required. Multiple `credentialType` values in one request SHALL be interpreted as a request for the intersection of the requested types (logical AND).
+For example, a request containing `credentialType` values `https://smarthealth.cards#covid19` and `https://smarthealth.cards#immunization` is a request for only those cards that are both COVID-19 cards and immunization cards (i.e., only those COVID-19 cards that are about immunizations).
 
 The following parameters are optional; clients MAY include them in a request, and servers MAY ignore them if present.
 
@@ -336,7 +336,15 @@ The **response** is a `Parameters` resource that includes one more more `verifia
 }
 ```
 
-In the response, an optional repeating `resourceLink` parameter can capture the link between any number of hosted FHIR resources and their derived representations within the verifiable credential's `.credentialSubject.fhirBundle`, allowing the health wallet to explictily understand these correspondences between `bundledResource` and `hostedResource`, without baking details about the hosted endpoint into the signed credential. The optional `vcIndex` value on a `resourceLink` can be used when a response contains more than one VC, to indicate which VC this resource link applies to. The `vcIndex` is a zero-based index of a `verifiableCredential` entry within the top-level `parameter` array.
+If no results are available, a `Parameters` resource without any `parameter` is returned:
+
+```json
+{
+  "resourceType": "Parameters"
+}
+```
+
+In the response, an optional repeating `resourceLink` parameter can capture the link between any number of hosted FHIR resources and their derived representations within the verifiable credential's `.credentialSubject.fhirBundle`, allowing the health wallet to explicitly understand these correspondences between `bundledResource` and `hostedResource`, without baking details about the hosted endpoint into the signed credential. The optional `vcIndex` value on a `resourceLink` can be used when a response contains more than one VC, to indicate which VC this resource link applies to. The `vcIndex` is a zero-based index of a `verifiableCredential` entry within the top-level `parameter` array.
 
 ```json
 {


### PR DESCRIPTION
- Give an example `Parameters` resource
- Update `OperationDefinition`
- Some drive-by typo fixes
- Resolves #163 