### PR TITLE
Missing close quote in index/spec

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -228,7 +228,7 @@ To ensure that all Health Cards can be represented in QR codes, issuers SHALL en
         * without `DomainResource.text` elements
         * without `CodeableConcept.text` elements
         * without `Coding.display` elements
-        * with `Bundle.entry.fullUrl` populated with short `resource`-scheme URIs (e.g., `{"fullUrl": "resource:0}`)
+        * with `Bundle.entry.fullUrl` populated with short `resource`-scheme URIs (e.g., `{"fullUrl": "resource:0"}`)
         * with `Reference.reference` populated with short `resource`-scheme URIs (e.g., `{"patient": {"reference": "resource:0"}}`)
 
 


### PR DESCRIPTION
In the section specifying criteria, `Bundle.entry.fullUrl` was missing a close quote on the resource URL.