### PR TITLE
Adds TLS requirements for issuer keyset

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 1.0.2 
+## 1.0.3
+
+Updated TLS requirements for issuer key set
+
+## 1.0.2
 
 Updated links to the HL7 Implementation Guide
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.3
+## 1.1.0
 
 Updated TLS requirements for issuer key set
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,11 +115,11 @@ If the issuer has more than one certificate for the same public key (e.g. partic
 Issuers SHALL publish their public keys as JSON Web Key Sets (see [RFC7517](https://tools.ietf.org/html/rfc7517#section-5)), available at `<<iss value from JWS>>` + `/.well-known/jwks.json`, with [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) enabled.
 
 The URL at `<<iss value from JWS>>` SHALL use the `https` scheme, and SHALL use the following TLS version 1.2 or 1.3 configurations:
-* For TLS 1.2, use a ciphersuite conforming to the following algorithm choices and _minimum_ cryptographic strength:
+* For TLS 1.2, support at least one ciphersuite conforming to the following algorithm choices and _minimum_ cryptographic strength:
   * Key exchange: ECDHE using a 256-bit curve
   * Authentication: ECDSA with a 256-bit curve, or RSA with a 2048-bit key
   * Session cipher: AES with a 128-bit key
-  * Cipher mode: CBC or CGM
+  * Cipher mode: CBC or GCM
   * Hash algorithm: SHA256
   * The following recommended ciphersuites adhere to these requirements:
     * TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,7 +113,7 @@ The public key listed in the first certificate in the `"x5c"` array SHALL match 
 If the issuer has more than one certificate for the same public key (e.g. participation in more than one trust community), then a separate JWK entry is used for each certificate with all JWK parameter values identical except `"x5c"`.
 
 
-Issuers SHALL publish their public keys as JSON Web Key Sets (see [RFC7517](https://tools.ietf.org/html/rfc7517#section-5)), available at `<<iss value from JWS>>` + `/.well-known/jwks.json`, with [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) enabled, using TLS version 1.2 following the IETF [BCP 195](https://www.rfc-editor.org/info/bcp195) recommendations or TLS version 1.3.
+Issuers SHALL publish their public keys as JSON Web Key Sets (see [RFC7517](https://tools.ietf.org/html/rfc7517#section-5)), available at `<<iss value from JWS>>` + `/.well-known/jwks.json`, with [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) enabled, using TLS version 1.2 following the IETF [BCP 195](https://www.rfc-editor.org/info/bcp195) recommendations or TLS version 1.3 (with any configuration).
 
 The URL at `<<iss value from JWS>>` SHALL use the `https` scheme and SHALL NOT include a trailing `/`. For example, `https://smarthealth.cards/examples/issuer` is a valid `iss` value (`https://smarthealth.cards/examples/issuer/` is **not**).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,9 +113,9 @@ The public key listed in the first certificate in the `"x5c"` array SHALL match 
 If the issuer has more than one certificate for the same public key (e.g. participation in more than one trust community), then a separate JWK entry is used for each certificate with all JWK parameter values identical except `"x5c"`.
 
 
-Issuers SHALL publish their public keys as JSON Web Key Sets (see [RFC7517](https://tools.ietf.org/html/rfc7517#section-5)), available at `<<iss value from JWS>>` + `/.well-known/jwks.json`, with [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) enabled, and using TLS version 1.2 following the IETF [BCP 195](https://www.rfc-editor.org/info/bcp195) recommendations or TLS version 1.3.
+Issuers SHALL publish their public keys as JSON Web Key Sets (see [RFC7517](https://tools.ietf.org/html/rfc7517#section-5)), available at `<<iss value from JWS>>` + `/.well-known/jwks.json`, with [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) enabled, using TLS version 1.2 following the IETF [BCP 195](https://www.rfc-editor.org/info/bcp195) recommendations or TLS version 1.3.
 
-The URL at `<<iss value from JWS>>` SHALL use the `https` scheme and SHALL NOT include a trailing `/`. For example, `https://smarthealth.cards/examples/issuer` is a valid `iss` value (`https://smarthealth.cards/examples/issuer/` is **not**). The 
+The URL at `<<iss value from JWS>>` SHALL use the `https` scheme and SHALL NOT include a trailing `/`. For example, `https://smarthealth.cards/examples/issuer` is a valid `iss` value (`https://smarthealth.cards/examples/issuer/` is **not**).
 
 **Signing keys** in the `.keys[]` array can be identified by `kid` following the requirements above (i.e., by filtering on `kty`, `use`, and `alg`).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,31 +112,10 @@ certificate or certificate chain (see [RFC7517](https://tools.ietf.org/html/rfc7
 The public key listed in the first certificate in the `"x5c"` array SHALL match the public key specified by the `"crv"`, `"x"`, and `"y"` parameters of the same JWK entry.
 If the issuer has more than one certificate for the same public key (e.g. participation in more than one trust community), then a separate JWK entry is used for each certificate with all JWK parameter values identical except `"x5c"`.
 
-Issuers SHALL publish their public keys as JSON Web Key Sets (see [RFC7517](https://tools.ietf.org/html/rfc7517#section-5)), available at `<<iss value from JWS>>` + `/.well-known/jwks.json`, with [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) enabled.
 
-The URL at `<<iss value from JWS>>` SHALL use the `https` scheme, and SHALL use the following TLS version 1.2 or 1.3 configurations:
-* For TLS 1.2, support at least one ciphersuite conforming to the following algorithm choices and _minimum_ cryptographic strength:
-  * Key exchange: ECDHE using a 256-bit curve
-  * Authentication: ECDSA with a 256-bit curve, or RSA with a 2048-bit key
-  * Session cipher: AES with a 128-bit key
-  * Cipher mode: CBC or GCM
-  * Hash algorithm: SHA256
-  * The following recommended ciphersuites adhere to these requirements:
-    * TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-    * TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-    * TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-    * TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-    * TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-    * TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
-    * TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-    * TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
-* For TLS 1.3, use one of these ciphersuites:
-    * TLS_AES_256_GCM_SHA384
-    * TLS_AES_128_GCM_SHA256
-* X.509 certificate SHALL use a 256-bit ECDSA or 2048-bit RSA key, must be valid, and trusted by major web browsers.
+Issuers SHALL publish their public keys as JSON Web Key Sets (see [RFC7517](https://tools.ietf.org/html/rfc7517#section-5)), available at `<<iss value from JWS>>` + `/.well-known/jwks.json`, with [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) enabled, and using TLS version 1.2 following the IETF [BCP 195](https://www.rfc-editor.org/info/bcp195) recommendations or TLS version 1.3.
 
-
-The URL SHALL NOT include a trailing `/`. For example, `https://smarthealth.cards/examples/issuer` is a valid `iss` value (`https://smarthealth.cards/examples/issuer/` is **not**).
+The URL at `<<iss value from JWS>>` SHALL use the `https` scheme and SHALL NOT include a trailing `/`. For example, `https://smarthealth.cards/examples/issuer` is a valid `iss` value (`https://smarthealth.cards/examples/issuer/` is **not**). The 
 
 **Signing keys** in the `.keys[]` array can be identified by `kid` following the requirements above (i.e., by filtering on `kty`, `use`, and `alg`).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,7 +114,29 @@ If the issuer has more than one certificate for the same public key (e.g. partic
 
 Issuers SHALL publish their public keys as JSON Web Key Sets (see [RFC7517](https://tools.ietf.org/html/rfc7517#section-5)), available at `<<iss value from JWS>>` + `/.well-known/jwks.json`, with [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) enabled.
 
-The URL at `<<iss value from JWS>>` SHALL use the `https` scheme and SHALL NOT include a trailing `/`. For example, `https://smarthealth.cards/examples/issuer` is a valid `iss` value (`https://smarthealth.cards/examples/issuer/` is **not**).
+The URL at `<<iss value from JWS>>` SHALL use the `https` scheme, and SHALL use the following TLS version 1.2 or 1.3 configurations:
+* For TLS 1.2, use a ciphersuite conforming to the following algorithm choices and _minimum_ cryptographic strength:
+  * Key exchange: ECDHE using a 256-bit curve
+  * Authentication: ECDSA with a 256-bit curve, or RSA with a 2048-bit key
+  * Session cipher: AES with a 128-bit key
+  * Cipher mode: CBC or CGM
+  * Hash algorithm: SHA256
+  * The following recommended ciphersuites adhere to these requirements:
+    * TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+    * TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+    * TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    * TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    * TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+    * TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+    * TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+    * TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+* For TLS 1.3, use one of these ciphersuites:
+    * TLS_AES_256_GCM_SHA384
+    * TLS_AES_128_GCM_SHA256
+* X.509 certificate SHALL use a 256-bit ECDSA or 2048-bit RSA key, must be valid, and trusted by major web browsers.
+
+
+The URL SHALL NOT include a trailing `/`. For example, `https://smarthealth.cards/examples/issuer` is a valid `iss` value (`https://smarthealth.cards/examples/issuer/` is **not**).
 
 **Signing keys** in the `.keys[]` array can be identified by `kid` following the requirements above (i.e., by filtering on `kty`, `use`, and `alg`).
 


### PR DESCRIPTION
There have been discussions about moving the [proposed TLS requirements](https://github.com/the-commons-project/vci-directory/pull/42) for the VCI directory to the core spec. ~~Here is proposal that explicitly cites the cryptographic requirements (without referring to 3rd party requirements).~~

9/16/2021 update: following some discussions, [bcp195](https://www.rfc-editor.org/info/bcp195) is used as an external requirement source, following usage in, e.g.,  [FHIR R4 security](https://hl7.org/fhir/r4/security.html#http), [QHIN Tech Framework](https://rce.sequoiaproject.org/wp-content/uploads/2021/07/QTF-V1-Draft.pdf). This seems to be a good set of recommendations for the core spec; downstream trust frameworks can always limit the requirements even more if needed. I changed the PR to reflect the language of the QHIN doc, to allow TLS 1.3 (not yet recommended by BCP 195). 