### PR TITLE
Use NIST IAL levels only

### DIFF
--- a/docs/ial.md
+++ b/docs/ial.md
@@ -1,5 +1,5 @@
 ---
-title: "Code System: Identity Assurance Level"
+title: "Code System: Identity Assurance Level (IAL)"
 ---
 
 Defining URL
@@ -11,20 +11,17 @@ Version
 License
 : <https://creativecommons.org/licenses/by/4.0/>
 
-This code system defines levels of identity assurance, based on [NIST 800-63-3](https://pages.nist.gov/800-63-3/sp800-63-3.html#52--assurance-levels).
+This code system defines Identity Assurance Level (IAL)s based on [NIST 800-63-3](https://pages.nist.gov/800-63-3/sp800-63-3.html#52--assurance-levels).  These codes may be used by Issuers of SMART Health Cards To record if/how a patient's identity was verified at the point of vaccination (i.e. point of care).
 
-These codes may be used by Issuers of SMART Health Cards to record if/how a patient's identity was verified at the point of care. For example, if a patient showed their driver's license to verify their name and date of birth when getting a vaccination, this would correspond to `IAL1.4`.
 
 The following codes are included in this code system:
 
 |Code|Display|
 |-|-|
-|`IAL1`|Name and birth date were self-asserted.|
-|`IAL1.2`|An unspecified ID was used to verify name and birth date.|
-|`IAL1.4`|A government-issued photo ID was used to verify name and birth date.|
+|`IAL1`|Low-level identity assurance.  Name and birth date were self-asserted or some document or credential identity was provided not meeting IAL 2 definition.|
 |`IAL2`|Either remote or in-person identity proofing is required. IAL2 requires identifying attributes to have been verified in person or remotely using, at a minimum, the procedures given in [NIST Special Publication 800-63A].|
 |`IAL3`|In-person identity proofing is required. Identifying attributes must be verified by an authorized CSP representative through examination of physical documentation as described in [NIST Special Publication 800-63A].|
 
-For `IAL1.4`, in the US, "government-issued photo ID" may include IDs such as a US state-issued driver's license, a US nationally-issued ID like a US passport, or a foreign passport.
-
-[NIST Special Publication 800-63A]: https://pages.nist.gov/800-63-3/sp800-63a.html
+Resources
+---------
+* Digital Identity Guidelines - NIST Special Publication 800-63-3A: https://pages.nist.gov/800-63-3/sp800-63a.html


### PR DESCRIPTION
For this use case, I am strongly recommending using NIST IAL levels ( 1, 2, or 3) and getting rid of "1.x".  This is optional information anyway.  When cases of "low identity assurance", place those as IAL 1.

While the notion of "between 1 and 2" could and should be addressed and it looks like it will be by NIST in revision 4.  See https://github.com/usnistgov/800-63-4/issues/1




