### PR TITLE
Specified per-SHC revocation

### DIFF
--- a/FAQ/security.md
+++ b/FAQ/security.md
@@ -27,6 +27,10 @@ If you don't recognize the key, are they tricking verifiers into thinking you ar
 
 Expired private keys should be deleted, the corresponding public keys should stay in the issuer published key set to allow verifiers to validate health cards issued using them. Revoked private keys (compromised, issued in error, etc.) should be deleted and removed from the published key set.
 
+### Some cards have been erroneously issued, can they be revoked
+
+Individual health cards issued by mistake can be revoked by listing the SHA-256 digest of their JWS is a revocation listed hosted by the issuer.
+
 ## User
 
 ### Can someone steal my health card?

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.0
+
+Specified Health Card revocation
+
 ## 1.1.1
 
 Added verifier guidance to ignore unrecognized VC types

--- a/docs/index.md
+++ b/docs/index.md
@@ -461,8 +461,6 @@ When reading a QR code, scanning software can recognize a SMART Health Card from
 
 # FAQ
 
-Technical security questions are covered in the [security FAQ page](https://github.com/smart-on-fhir/health-cards/blob/main/FAQ/security.md).
-
 ## Can a SMART Health Card be used as a form of identification?
 
 No. SMART Health Cards are designed for use *alongside* existing forms of identification (e.g., a driver's license in person, or an online ID verification service). A SMART Health Card is a non-forgeable digital artifact analogous to a paper record on official letterhead. Concretely, the problem SMART Health Cards solve is one of provenance: a digitally signed SMART Health Card is a credential that guarantees that a specific issuer generated the record. The duty of verifying that the person presenting a Health Card *is* the subject of the data within the Health Card (or is authorized to act on behalf of this data subject) falls to the person or system receiving and validating a Health Card.

--- a/docs/index.md
+++ b/docs/index.md
@@ -163,7 +163,7 @@ are clinically relevant. However, if a private signing key is compromised, then 
 ### Revocation
 
 Individual Health Cards MAY be revoked by an issuer using the digest of their JWS representation. To revoke a card, an issuer:
-1. Calculates the SHA-256 `<<digest>>` of the utf-8 encoding of the `<<Health Card as JWS>>`
+1. Calculates the base64url-encoded SHA-256 `<<digest>>` of the utf-8 encoding of the `<<Health Card as JWS>>`
 2. Add the digest to their `https://"<<Issuer URL>>"/.well-known/revoked-shcs-by/kid/"<<kid>>".json`, where
    - `"<<Issuer URL>>"` is the issuer URL listed in the Health Card,
    - `"<<kid>>"` is the key ID with which the Health Card was signed,


### PR DESCRIPTION
We are starting to hear interest in revocation schemes from jurisdictions that are detecting fraud in their own issuance history. In order to promote interoperability, the framework should specify an optional mechanism to enable this.

See related discussion in #204.

~~The proposed way is to add the SHA-256 digest of the card's JWS to a per-`kid` revocation list; this results in a unique string that can be recognized by verifiers. Associating the lists with the corresponding issuing key limits the size of the card revocation list as there will be an upper max limit when the key is rotated.~~

 After further analysis, the approached specified here will not work. Due to [ECDSA malleability](https://yondon.blog/2019/01/01/how-not-to-use-ecdsa/), `hash(JWS)` cannot be used as a revocation identifier, as it can be evaded.