### PR TITLE
Fix example-02 card types

### DIFF
--- a/generate-examples/src/index.ts
+++ b/generate-examples/src/index.ts
@@ -37,7 +37,7 @@ const exampleBundleInfo: BundleInfo[] = [
     'https://smarthealth.cards#immunization',
     'https://smarthealth.cards#covid19',
   ]},
-  {fixture: DrFixture, issuerIndex: 0, types: ['https://smarthealth.cards#immunization', 'https://smarthealth.cards#covid19']},
+  {fixture: DrFixture, issuerIndex: 0, types: []},
   {fixture: RevokedFixture, issuerIndex: 0, types: ['https://smarthealth.cards#immunization', 'https://smarthealth.cards#covid19']},
 ];
 


### PR DESCRIPTION
Removed example-02 types added by mistake in commit #14d5bc.