### PR TITLE
Document suggested Deep Link format

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -315,21 +315,21 @@ For a more seamless user experience when FHIR API connections are already in pla
 
 ### via “Deep Link”
 
-So a user can import one or more SMART Health Cards to their Health Wallet with one tap or click, issuers can create app specific “deep links”. These are available on most modern operating systems and will open link clicks in a native app if it's installed on the computer or smartphone.
+For a user to import one or more SMART Health Cards to their Health Wallet with one tap or click, issuers can display app specific “deep links”. These are available on most modern operating systems and will open link clicks in a native app if the respective app is installed on the computer or smartphone.
 
-Even though apps can define their own deep link syntax, for consistency we recommend Health Wallets support the following format:
+Apps can define their own deep link syntax. However, for consistency, we recommend Health Wallets support the following format:
 
 ```
 https://<<associated domain>><<'/'optional path>>/SMARTHealthCard/#(<<Verifiable Credential as JWS>><<','0+ more JWS>>)
 ```
 
-A hypothetical deep link into an app registered for `example.com` with two SMART Health Cards would look like this (actual JWS payload shortened for readability):
+A hypothetical deep link into an app registered for `example.com` with two SMART Health Cards would look something like this (actual JWS payload shortened for readability):
 
 ```text
 https://app.example.com/i/SMARTHealthCard/#(eyJhbGc.dVPBbtswDP.Xo3dhlA,eyJhbGc.xVVNc9MwEP.B3KT7OD)
 ```
 
-The Health Wallet can now parse the one or more JWT and present an import option to the user.
+The Health Wallet app can now parse the JWS and present them for import to the user.
 
 
 #### Discovery of FHIR Support

--- a/docs/index.md
+++ b/docs/index.md
@@ -313,6 +313,25 @@ Finally, the Health Wallet asks the user if they want to save any/all of the sup
 
 For a more seamless user experience when FHIR API connections are already in place, results may also be conveyed through a FHIR API `$health-cards-issue` operation defined [here](../artifacts/operation-patient-i-health-cards-issue.json). For issuers that support SMART on FHIR access, the Health Wallet MAY request authorization with SMART on FHIR scopes (e.g., `launch/patient patient/Immunization.read` for an Immunization use case). This allows the Health Wallet to automatically request issuance of VCs, including requests for periodic updates.
 
+### via “Deep Link”
+
+So a user can import one or more SMART Health Cards to their Health Wallet with one tap or click, issuers can create app specific “deep links”. These are available on most modern operating systems and will open link clicks in a native app if it's installed on the computer or smartphone.
+
+Even though apps can define their own deep link syntax, for consistency we recommend Health Wallets support the following format:
+
+```
+https://<<associated domain>><<'/'optional path>>/SMARTHealthCard/#(<<Verifiable Credential as JWS>><<','0+ more JWS>>)
+```
+
+A hypothetical deep link into an app registered for `example.com` with two SMART Health Cards would look like this (actual JWS payload shortened for readability):
+
+```text
+https://app.example.com/i/SMARTHealthCard/#(eyJhbGc.dVPBbtswDP.Xo3dhlA,eyJhbGc.xVVNc9MwEP.B3KT7OD)
+```
+
+The Health Wallet can now parse the one or more JWT and present an import option to the user.
+
+
 #### Discovery of FHIR Support
 
 A SMART on FHIR Server capable of issuing VCs according to this specification SHALL advertise its support by adding the `health-cards` capability to its `/.well-known/smart-configuration` JSON file. For example:

--- a/docs/index.md
+++ b/docs/index.md
@@ -313,24 +313,27 @@ Finally, the Health Wallet asks the user if they want to save any/all of the sup
 
 For a more seamless user experience when FHIR API connections are already in place, results may also be conveyed through a FHIR API `$health-cards-issue` operation defined [here](../artifacts/operation-patient-i-health-cards-issue.json). For issuers that support SMART on FHIR access, the Health Wallet MAY request authorization with SMART on FHIR scopes (e.g., `launch/patient patient/Immunization.read` for an Immunization use case). This allows the Health Wallet to automatically request issuance of VCs, including requests for periodic updates.
 
-### via “Deep Link”
+### via "Deep Link"
 
-For a user to import one or more SMART Health Cards to their Health Wallet with one tap or click, issuers can display app specific “deep links”. These are available on most modern operating systems and will open link clicks in a native app if the respective app is installed on the computer or smartphone.
+For a user to import one or more SMART Health Cards to their Health Wallet with one tap or click, issuers can display app-specific "deep links". These are available on most modern operating systems and will open in a native app if the respective app is installed on the computer or smartphone.
 
-Apps can define their own deep link syntax. However, for consistency, we recommend Health Wallets support the following format:
+Apps can define their own deep link syntax. However, for consistency we recommend Health Wallets support the following format:
 
 ```
-https://<<associated domain>><<'/'optional path>>/SMARTHealthCard/#(<<Verifiable Credential as JWS>><<','0+ more JWS>>)
+<<app-specific deep link base URL>>#(<<Verifiable Credential as JWS>><<','0+ more JWS>>)
 ```
 
-A hypothetical deep link into an app registered for `example.com` with two SMART Health Cards would look something like this (actual JWS payload shortened for readability):
+To follow this recommendation, deep link base URLs SHALL use a secure protocol (e.g., `https://`), and SHOULD end with `/SMARTHealthCard/`.
+   
+Note that the recommended format includes a `#` fragment to ensure that JWS content is not transmitted to the server in the event that an app-specific deep link is opened in a browser context (e.g., on a device where the app has not been installed).
+
+For a concrete example, consider an app whose deep link base is `https://app.example.com/i/SMARTHealthCard/`. A deep link to import two SMART Health Cards into the app would look something like this (actual JWS payload shortened for readability):
 
 ```text
 https://app.example.com/i/SMARTHealthCard/#(eyJhbGc.dVPBbtswDP.Xo3dhlA,eyJhbGc.xVVNc9MwEP.B3KT7OD)
 ```
 
-The Health Wallet app can now parse the JWS and present them for import to the user.
-
+After OS-mediated redirection, the Health Wallet app can now parse each JWS and present the collection for import to the user.
 
 #### Discovery of FHIR Support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -336,7 +336,7 @@ https://app.example.com/i/SMARTHealthCard/#{"verifiableCredential":["eyJhbGc.dVP
 With proper URL encoding a link will look like:
 
 ```html
-<a href="https://app.example.com/i/SMARTHealthCard/#%7B%22verifiableCredential%22%3A%20%5B%22eyJhbGc.dVPBbtswDP.Xo3dhlA%22%2C%22eyJhbGc.xVVNc9MwEP.B3KT7OD%22%5D%7D">
+<a href="https://app.example.com/i/SMARTHealthCard/#%7B%22verifiableCredential%22%3A%5B%22eyJhbGc.dVPBbtswDP.Xo3dhlA%22%2C%22eyJhbGc.xVVNc9MwEP.B3KT7OD%22%5D%7D">
   Link Text
 </a>
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -317,20 +317,28 @@ For a more seamless user experience when FHIR API connections are already in pla
 
 For a user to import one or more SMART Health Cards to their Health Wallet with one tap or click, issuers can display app-specific "deep links". These are available on most modern operating systems and will open in a native app if the respective app is installed on the computer or smartphone.
 
-Apps can define their own deep link syntax. However, for consistency we recommend Health Wallets support the following format:
+Apps can define their own deep link syntax. However, for consistency we recommend Health Wallets support the following format, which re-uses the JSON format defined for [file download](#via-file-download):
 
 ```
-<<app-specific deep link base URL>>#(<<Verifiable Credential as JWS>><<','0+ more JWS>>)
+<<app-specific deep link base URL>>#{"verifiableCredential":["<<Verifiable Credential as JWS>>"<<','0+ more JWS>>]}
 ```
 
 To follow this recommendation, deep link base URLs SHALL use a secure protocol (e.g., `https://`), and SHOULD end with `/SMARTHealthCard/`.
    
-Note that the recommended format includes a `#` fragment to ensure that JWS content is not transmitted to the server in the event that an app-specific deep link is opened in a browser context (e.g., on a device where the app has not been installed).
+Note that the recommended format serves the JWS content in a `#` fragment to ensure that no data is transmitted to the server in the event that an app-specific deep link is opened in a browser context (e.g., on a device where the app has not been installed).
 
 For a concrete example, consider an app whose deep link base is `https://app.example.com/i/SMARTHealthCard/`. A deep link to import two SMART Health Cards into the app would look something like this (actual JWS payload shortened for readability):
 
 ```text
-https://app.example.com/i/SMARTHealthCard/#(eyJhbGc.dVPBbtswDP.Xo3dhlA,eyJhbGc.xVVNc9MwEP.B3KT7OD)
+https://app.example.com/i/SMARTHealthCard/#{"verifiableCredential":["eyJhbGc.dVPBbtswDP.Xo3dhlA","eyJhbGc.xVVNc9MwEP.B3KT7OD"]}
+```
+
+With proper URL encoding a link will look like:
+
+```html
+<a href="https://app.example.com/i/SMARTHealthCard/#%7B%22verifiableCredential%22%3A%20%5B%22eyJhbGc.dVPBbtswDP.Xo3dhlA%22%2C%22eyJhbGc.xVVNc9MwEP.B3KT7OD%22%5D%7D">
+  Link Text
+</a>
 ```
 
 After OS-mediated redirection, the Health Wallet app can now parse each JWS and present the collection for import to the user.


### PR DESCRIPTION
The suggested deep link format uses the URL fragment (delimited with `#`) and starts with an opening parenthesis `(`, followed by the raw JWS, a comma separating any further JWS if necessary, and a closing parenthesis `)`. This allows for percent-encoding free representation of the payload(s) in the fragment and allows detection of the payload type by combining knowledge of the path (suggested as containing `SMARTHealthCard`) and the `()` bounds.